### PR TITLE
Allow links to be clicked inside of modal.

### DIFF
--- a/jquery.avgrund.js
+++ b/jquery.avgrund.js
@@ -51,14 +51,14 @@
 
 			// close popup by clicking outside it
 			function onDocumentClick(e) {
-				e.preventDefault();
-
 				if (options.closeByDocument) {
 					if ($(e.target).is('.avgrund-overlay, .avgrund-close')) {
+						e.preventDefault();
 						deactivate();
 					}
 				} else {
 					if ($(e.target).is('.avgrund-close')) {
+						e.preventDefault();
 						deactivate();
 					}
 				}


### PR DESCRIPTION
So PR #34 was actually too heavy handed. It prevents links from being clicked, even when they're inside of the modal.

This allows anchor tags inside of the modal to be clicked. :dancer: Thanks! :cake: 
